### PR TITLE
maru: Change Android.mk to Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,19 @@
+//
+// Copyright 2020 The Maru OS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+//
+subdirs = [
+    "src"
+]
+

--- a/src/Android.bp
+++ b/src/Android.bp
@@ -1,0 +1,112 @@
+//
+// Copyright 2020 The Maru OS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// LXC works fine with warnings so bypass Android's default -Werror flag
+common_CFLAGS = [
+    "-Wno-error",
+    "-DLXCROOTFSMOUNT=\"/system/lib/lxc/rootfs\"",
+    "-DLXCPATH=\"/data/maru/containers\"",
+    "-DLXC_GLOBAL_CONF=\"/system/maru/lxc/etc/lxc/lxc.conf\"",
+    "-DLXCINITDIR=\"/system/maru/lxc/libexec\"",
+    "-DLIBEXECDIR=\"/system/maru/lxc/libexec\"",
+    "-DLXCTEMPLATEDIR=\"/system/maru/lxc/share/lxc/templates\"",
+    "-DLOGPATH=\"/data/maru/containers\"",
+    "-DLXC_DEFAULT_CONFIG=\"/system/maru/lxc/etc/lxc/default.conf\"",
+    "-DLXC_USERNIC_DB=\"/cache/lxc/nics\"",
+    "-DLXC_USERNIC_CONF=\"/system/maru/lxc/etc/lxc/lxc-usernet\"",
+    "-DDEFAULT_CGROUP_PATTERN=\"/lxc/%n\"",
+    "-DRUNTIME_PATH=\"/cache\"",
+    "-DSBINDIR=\"/system/maru/lxc/sbin\"",
+]
+
+cc_defaults {
+    name: "lxc-defaults",
+    cflags: common_CFLAGS,
+    vendor: true,
+    local_include_dirs: ["include", "lxc", "lxc/lsm", "lxc/legacy"],
+}
+
+// -----------------------------------------------------------------------------
+//  liblxc
+
+cc_library_shared {
+    name: "liblxc",
+    defaults: ["lxc-defaults"],
+    srcs: [
+        "include/ifaddrs.c",
+        "include/openpty.c",
+        "include/lxcmntent.c",
+        "lxc/arguments.c",
+        "lxc/bdev.c",
+        "lxc/commands.c",
+        "lxc/start.c",
+        "lxc/execute.c",
+        "lxc/monitor.c",
+        "lxc/console.c",
+        "lxc/freezer.c",
+        "lxc/error.c",
+        "lxc/parse.c",
+        "lxc/cgfs.c",
+        "lxc/cgroup.c",
+        "lxc/initutils.c",
+        "lxc/utils.c",
+        "lxc/sync.c",
+        "lxc/namespace.c",
+        "lxc/conf.c",
+        "lxc/confile.c",
+        "lxc/state.c",
+        "lxc/log.c",
+        "lxc/attach.c",
+        "lxc/network.c",
+        "lxc/nl.c",
+        "lxc/rtnl.c",
+        "lxc/genl.c",
+        "lxc/caps.c",
+        "lxc/mainloop.c",
+        "lxc/af_unix.c",
+        "lxc/lxcutmp.c",
+        "lxc/lxclock.c",
+        "lxc/lxccontainer.c",
+    ],
+}
+
+cc_binary {
+    name: "lxc-start",
+    defaults: ["lxc-defaults"],
+    srcs: ["lxc/lxc_start.c"],
+    shared_libs: ["liblxc"],
+}
+
+cc_binary {
+    name: "lxc-stop",
+    defaults: ["lxc-defaults"],
+    srcs: ["lxc/lxc_stop.c"],
+    shared_libs: ["liblxc"],
+}
+
+cc_binary {
+    name: "lxc-console",
+    defaults: ["lxc-defaults"],
+    srcs: ["lxc/lxc_console.c"],
+    shared_libs: ["liblxc"],
+}
+
+cc_binary {
+    name: "lxc-attach",
+    defaults: ["lxc-defaults"],
+    srcs: ["lxc/lxc_attach.c"],
+    shared_libs: ["liblxc"],
+}

--- a/src/lxc/Android.mk
+++ b/src/lxc/Android.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 The Maru OS Project
+# Copyright 2016-2020 The Maru OS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,112 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# converted to Android.mk from external/lxc/src/lxc/Makefile.am
-
-# -----------------------------------------------------------------------------
-#  liblxc
-
-LOCAL_PATH := $(call my-dir)
-include $(CLEAR_VARS)
-
-LOCAL_MODULE := liblxc
-
-LOCAL_SRC_FILES := \
-	arguments.c \
-	bdev.c \
-	commands.c \
-	start.c \
-	execute.c \
-	monitor.c \
-	console.c \
-	freezer.c \
-	error.c \
-	parse.c \
-	cgfs.c \
-	cgroup.c \
-	initutils.c \
-	utils.c \
-	sync.c \
-	namespace.c \
-	conf.c \
-	confile.c \
-	state.c \
-	log.c \
-	attach.c \
-	network.c \
-	nl.c \
-	rtnl.c \
-	genl.c \
-	caps.c \
-	mainloop.c \
-	af_unix.c \
-	lxcutmp.c \
-	lxclock.c \
-	lxccontainer.c
-
-# only on bionic
-LOCAL_SRC_FILES += \
-	../include/ifaddrs.c \
-	../include/openpty.c \
-	../include/lxcmntent.c
-
-# for static config.h
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
-
-# LXC works fine with warnings so bypass Android's default -Werror flag
-LOCAL_CFLAGS += -Wno-error
-
-LOCAL_CFLAGS += \
-	-DLXCROOTFSMOUNT=\"/system/lib/lxc/rootfs\" \
-	-DLXCPATH=\"/data/maru/containers\" \
-	-DLXC_GLOBAL_CONF=\"/system/maru/lxc/etc/lxc/lxc.conf\" \
-	-DLXCINITDIR=\"/system/maru/lxc/libexec\" \
-	-DLIBEXECDIR=\"/system/maru/lxc/libexec\" \
-	-DLXCTEMPLATEDIR=\"/system/maru/lxc/share/lxc/templates\" \
-	-DLOGPATH=\"/data/maru/containers\" \
-	-DLXC_DEFAULT_CONFIG=\"/system/maru/lxc/etc/lxc/default.conf\" \
-	-DLXC_USERNIC_DB=\"/cache/lxc/nics\" \
-	-DLXC_USERNIC_CONF=\"/system/maru/lxc/etc/lxc/lxc-usernet\" \
-	-DDEFAULT_CGROUP_PATTERN=\"/lxc/%n\" \
-	-DRUNTIME_PATH=\"/cache\" \
-	-DSBINDIR=\"/system/maru/lxc/sbin\"
-
-include $(BUILD_SHARED_LIBRARY)
-
-# -----------------------------------------------------------------------------
-#  LXC binaries
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := lxc-start
-LOCAL_SRC_FILES := lxc_start.c
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
-LOCAL_SHARED_LIBRARIES := liblxc
-include $(BUILD_EXECUTABLE)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := lxc-stop
-LOCAL_SRC_FILES := lxc_stop.c
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
-LOCAL_SHARED_LIBRARIES := liblxc
-include $(BUILD_EXECUTABLE)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := lxc-console
-LOCAL_SRC_FILES := lxc_console.c
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
-LOCAL_SHARED_LIBRARIES := liblxc
-include $(BUILD_EXECUTABLE)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := lxc-attach
-LOCAL_SRC_FILES := lxc_attach.c
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
-LOCAL_SHARED_LIBRARIES := liblxc
-include $(BUILD_EXECUTABLE)
-
 # -----------------------------------------------------------------------------
 #  LXC rootfs mount (required!)
+
+LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := lxc-rootfs-mnt-README


### PR DESCRIPTION
It uses the similar method of [lxc-android](https://github.com/ppoffice/lxc-android).

I have tested it with pixel building and `lxc-start --name default`  and `lxc-stop --name default`.