### PR TITLE
Remove lxc from vendor

### DIFF
--- a/src/Android.bp
+++ b/src/Android.bp
@@ -35,7 +35,6 @@ common_CFLAGS = [
 cc_defaults {
     name: "lxc-defaults",
     cflags: common_CFLAGS,
-    vendor: true,
     local_include_dirs: ["include", "lxc", "lxc/lsm", "lxc/legacy"],
 }
 


### PR DESCRIPTION
`Perspectived` needs `liblxc`, and it is FWK-only(frameworks-only) library, so it needs its dependencies can be accessed by framework when ` BOARD_VNDK_VERSION` is enabled, for example sargo. If we add flag `vendor: true` for `liblxc`, it will break the building with link restriction. I think MaruOS is not ready for GSI, and its core binaries are packaged into `system.img`, and we should remove `vendor: true` from `liblxc` to pass building before GSI ready.

The related document about `VNDK` link restriction is here: https://source.android.com/devices/architecture/vndk/build-system.